### PR TITLE
Migrate proj4j dependency to org.locationtech.proj4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Build this repository using Eclipse and/or Maven:
 ### Remote Dependencies ###
 
 * [Simple Features](https://github.com/ngageoint/simple-features-java) (The MIT License (MIT)) - Simple Features Lib
-* [Proj4J](http://trac.osgeo.org/proj4j/) (Apache License, Version 2.0) - Projection Library
+* [Proj4J](https://github.com/locationtech/proj4j) (Apache License, Version 2.0) - Projection Library

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 			<version>2.0.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.osgeo</groupId>
+			<groupId>org.locationtech.proj4j</groupId>
 			<artifactId>proj4j</artifactId>
-			<version>0.1.0</version>
+			<version>0.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/mil/nga/sf/proj/GeometryProjectionTransform.java
+++ b/src/main/java/mil/nga/sf/proj/GeometryProjectionTransform.java
@@ -18,7 +18,7 @@ import mil.nga.sf.TIN;
 import mil.nga.sf.Triangle;
 import mil.nga.sf.util.SFException;
 
-import org.osgeo.proj4j.ProjCoordinate;
+import org.locationtech.proj4j.ProjCoordinate;
 
 /**
  * Geometry Projection Transform

--- a/src/main/java/mil/nga/sf/proj/Projection.java
+++ b/src/main/java/mil/nga/sf/proj/Projection.java
@@ -1,10 +1,10 @@
 package mil.nga.sf.proj;
 
-import org.osgeo.proj4j.CoordinateReferenceSystem;
-import org.osgeo.proj4j.parser.Proj4Keyword;
-import org.osgeo.proj4j.proj.LongLatProjection;
-import org.osgeo.proj4j.units.Unit;
-import org.osgeo.proj4j.units.Units;
+import org.locationtech.proj4j.CoordinateReferenceSystem;
+import org.locationtech.proj4j.parser.Proj4Keyword;
+import org.locationtech.proj4j.proj.LongLatProjection;
+import org.locationtech.proj4j.units.Unit;
+import org.locationtech.proj4j.units.Units;
 
 /**
  * Single Projection for an authority and code

--- a/src/main/java/mil/nga/sf/proj/ProjectionFactory.java
+++ b/src/main/java/mil/nga/sf/proj/ProjectionFactory.java
@@ -8,8 +8,8 @@ import java.util.logging.Logger;
 
 import mil.nga.sf.util.SFException;
 
-import org.osgeo.proj4j.CRSFactory;
-import org.osgeo.proj4j.CoordinateReferenceSystem;
+import org.locationtech.proj4j.CRSFactory;
+import org.locationtech.proj4j.CoordinateReferenceSystem;
 
 /**
  * Projection factory for coordinate projections and transformations

--- a/src/main/java/mil/nga/sf/proj/ProjectionTransform.java
+++ b/src/main/java/mil/nga/sf/proj/ProjectionTransform.java
@@ -7,9 +7,9 @@ import mil.nga.sf.Geometry;
 import mil.nga.sf.GeometryEnvelope;
 import mil.nga.sf.Point;
 
-import org.osgeo.proj4j.CoordinateTransform;
-import org.osgeo.proj4j.CoordinateTransformFactory;
-import org.osgeo.proj4j.ProjCoordinate;
+import org.locationtech.proj4j.CoordinateTransform;
+import org.locationtech.proj4j.CoordinateTransformFactory;
+import org.locationtech.proj4j.ProjCoordinate;
 
 /**
  * Projection transform wrapper


### PR DESCRIPTION
Locationtech released version 0.2.0 of [proj4j](https://github.com/locationtech/proj4j) this past week, which should be a drop-in replacement except for the changed group id.