### PR TITLE
Bump proj4j to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.locationtech.proj4j</groupId>
 			<artifactId>proj4j</artifactId>
-			<version>0.2.0</version>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Sorry for the churn. They appear to have decided to graduate from 0.2.0 to 1.0.0 since #3 was merged.